### PR TITLE
Fix minor typo

### DIFF
--- a/docs/module-reference.rst
+++ b/docs/module-reference.rst
@@ -254,7 +254,7 @@ Optimizers
    GradientBasedOptimizer
    Adam
    GradientDescent
-   NetwonMethod
+   NewtonMethod
    RMSprop
    :parts: 1
 
@@ -292,7 +292,7 @@ parameters).
    :nosignatures:
 
    GradientDescent
-   NetwonMethod
+   NewtonMethod
    Adam
    RMSprop
 

--- a/examples/gradient-based-offpolicy/q_learning_offpolicy.py
+++ b/examples/gradient-based-offpolicy/q_learning_offpolicy.py
@@ -79,7 +79,7 @@ from gymnasium.wrappers import TimeLimit
 from more_itertools import pairwise
 
 from mpcrl import Agent, LearnableParameter, LearnableParametersDict, LstdQLearningAgent
-from mpcrl.optim import NetwonMethod
+from mpcrl.optim import NewtonMethod
 from mpcrl.util.control import dlqr
 from mpcrl.wrappers.agents import Evaluate, Log, RecordUpdates
 from mpcrl.wrappers.envs import MonitorEpisodes
@@ -293,7 +293,7 @@ if __name__ == "__main__":
                     learnable_parameters=learnable_pars,
                     discount_factor=mpc.discount_factor,
                     update_strategy=1,
-                    optimizer=NetwonMethod(learning_rate=5e-2),
+                    optimizer=NewtonMethod(learning_rate=5e-2),
                     hessian_type="approx",
                     record_td_errors=True,
                     remove_bounds_on_initial_action=True,

--- a/examples/gradient-based-onpolicy/q_learning.py
+++ b/examples/gradient-based-onpolicy/q_learning.py
@@ -74,7 +74,7 @@ from gymnasium.spaces import Box
 from gymnasium.wrappers import TimeLimit
 
 from mpcrl import LearnableParameter, LearnableParametersDict, LstdQLearningAgent
-from mpcrl.optim import NetwonMethod
+from mpcrl.optim import NewtonMethod
 from mpcrl.util.control import dlqr
 from mpcrl.wrappers.agents import Log, RecordUpdates
 from mpcrl.wrappers.envs import MonitorEpisodes
@@ -262,7 +262,7 @@ if __name__ == "__main__":
                 learnable_parameters=learnable_pars,
                 discount_factor=mpc.discount_factor,
                 update_strategy=1,
-                optimizer=NetwonMethod(learning_rate=5e-2),
+                optimizer=NewtonMethod(learning_rate=5e-2),
                 hessian_type="approx",
                 record_td_errors=True,
                 remove_bounds_on_initial_action=True,

--- a/src/mpcrl/optim/__init__.py
+++ b/src/mpcrl/optim/__init__.py
@@ -10,7 +10,7 @@ __all__ = [
     "GradientDescent",
     "GradientFreeOptimizer",
     "GD",
-    "NetwonMethod",
+    "NewtonMethod",
     "NM",
     "RMSprop",
 ]
@@ -19,8 +19,8 @@ from .adam import Adam
 from .gradient_based_optimizer import GradientBasedOptimizer
 from .gradient_descent import GradientDescent
 from .gradient_free_optimizer import GradientFreeOptimizer
-from .newton_method import NetwonMethod
+from .newton_method import NewtonMethod
 from .rmsprop import RMSprop
 
 GD = GradientDescent
-NM = NetwonMethod
+NM = NewtonMethod

--- a/src/mpcrl/optim/newton_method.py
+++ b/src/mpcrl/optim/newton_method.py
@@ -9,10 +9,10 @@ from ..util.math import cholesky_added_multiple_identity
 from .gradient_based_optimizer import GradientBasedOptimizer, LrType, SymType
 
 
-class NetwonMethod(GradientBasedOptimizer[SymType, LrType]):
-    r"""Second-order gradient-based Netwon's method.
+class NewtonMethod(GradientBasedOptimizer[SymType, LrType]):
+    r"""Second-order gradient-based Newton's method.
 
-    In constrast to the first-order methods, the Netwon's method uses also the Hessian
+    In constrast to the first-order methods, the Newton's method uses also the Hessian
     of the loss function to compute the update. The unconstrained update is given by
 
     .. math:: \theta \gets \theta - \alpha H^{-1} g.
@@ -152,7 +152,7 @@ def _nm_unconstrained(
     weight_decay: float,
     cho_solve_kwargs: dict,
 ) -> np.ndarray:
-    """Computes the update's change according to the Netwon's Method."""
+    """Computes the update's change according to the Newton's Method."""
     if weight_decay <= 0.0:
         return -lr * cho_solve((L, True), g, **cho_solve_kwargs)
     return -np.linalg.solve(
@@ -170,7 +170,7 @@ def _nm_constrained(
     cho_before_update: bool,
     cho_solve_kwargs: dict,
 ) -> tuple[np.ndarray, np.ndarray]:
-    """Computes the update's change according to the Netwon's Method, which is solved
+    """Computes the update's change according to the Newton's Method, which is solved
     numerically due to the presence of constraints."""
     if weight_decay <= 0.0:
         if cho_before_update:

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -48,7 +48,7 @@ from mpcrl import (
     WarmStartStrategy,
 )
 from mpcrl import exploration as E
-from mpcrl.optim import GradientDescent, NetwonMethod
+from mpcrl.optim import GradientDescent, NewtonMethod
 from mpcrl.util.geometry import ConvexPolytopeUniformSampler
 from mpcrl.wrappers.agents import Evaluate, Log, RecordUpdates
 from mpcrl.wrappers.envs import MonitorEpisodes
@@ -80,7 +80,7 @@ class TestExamples(unittest.TestCase):
                     mpc=mpc,
                     learnable_parameters=learnable_pars,
                     discount_factor=mpc.discount_factor,
-                    optimizer=NetwonMethod(
+                    optimizer=NewtonMethod(
                         learning_rate=5e-2,
                         max_percentage_update=1e3,  # does nothing; allows to test qp
                     ),
@@ -272,7 +272,7 @@ class TestExamples(unittest.TestCase):
                         learnable_parameters=learnable_pars,
                         discount_factor=mpc.discount_factor,
                         update_strategy=1,
-                        optimizer=NetwonMethod(learning_rate=5e-2),
+                        optimizer=NewtonMethod(learning_rate=5e-2),
                         hessian_type="approx",
                         record_td_errors=True,
                         remove_bounds_on_initial_action=True,

--- a/tests/test_optim.py
+++ b/tests/test_optim.py
@@ -171,10 +171,10 @@ class TestGradientDescent(unittest.TestCase):
         np.testing.assert_array_equal(learnable_pars.value, theta - 0.1 * g)
 
 
-class TestNetwonMethod(unittest.TestCase):
+class TestNewtonMethod(unittest.TestCase):
     @parameterized.expand(product((0.0, SMALL), (False, True)))
     def test_update__unconstrained(self, w: float, cho_before_update: bool):
-        opt = O.NetwonMethod(0.1, weight_decay=w, cho_before_update=cho_before_update)
+        opt = O.NewtonMethod(0.1, weight_decay=w, cho_before_update=cho_before_update)
         learnable_pars = LEARNABLE_PARS.copy(deep=True)
         learnable_pars.value = theta = np.random.randn(N_PARAMS)
         opt.set_learnable_parameters(learnable_pars)
@@ -191,7 +191,7 @@ class TestNetwonMethod(unittest.TestCase):
     def test_update__unconstrained__with_identity_hessian(
         self, w: float, cho_before_update: bool
     ):
-        opt = O.NetwonMethod(0.1, weight_decay=w, cho_before_update=cho_before_update)
+        opt = O.NewtonMethod(0.1, weight_decay=w, cho_before_update=cho_before_update)
         learnable_pars = LEARNABLE_PARS.copy(deep=True)
         learnable_pars.value = theta = np.random.randn(N_PARAMS)
         opt.set_learnable_parameters(learnable_pars)
@@ -205,7 +205,7 @@ class TestNetwonMethod(unittest.TestCase):
     def test_update__constrained__with_large_bounds_with_identity_hessian(
         self, w: float, cho_before_update: bool
     ):
-        opt = O.NetwonMethod(0.1, weight_decay=w, cho_before_update=cho_before_update)
+        opt = O.NewtonMethod(0.1, weight_decay=w, cho_before_update=cho_before_update)
         learnable_pars = LEARNABLE_PARS.copy(deep=True)
         learnable_pars.value = theta = np.random.randn(N_PARAMS)
         learnable_pars.lb = -np.abs(theta) * 100
@@ -221,7 +221,7 @@ class TestNetwonMethod(unittest.TestCase):
     def test_update__constrained__with_small_bounds(
         self, w: float, cho_before_update: bool
     ):
-        opt = O.NetwonMethod(0.1, weight_decay=w, cho_before_update=cho_before_update)
+        opt = O.NewtonMethod(0.1, weight_decay=w, cho_before_update=cho_before_update)
         learnable_pars = LEARNABLE_PARS.copy(deep=True)
         learnable_pars.value = theta = np.random.randn(N_PARAMS)
         lb = learnable_pars.lb = theta - np.abs(theta) * 5e-2


### PR DESCRIPTION
This PR fixes a few small typos where `Newton` is spelled as `Netwon`.
Thanks again for making the code public :)