### PR TITLE
Agent constructor mpc tuple

### DIFF
--- a/src/mpcrl/agents/common/agent.py
+++ b/src/mpcrl/agents/common/agent.py
@@ -173,7 +173,7 @@ class Agent(Named, SupportsDeepcopyAndPickle, AgentCallbackMixin, Generic[SymTyp
         self._last_action_on_fail = use_last_action_on_fail
         self._last_solution: Optional[Solution[SymType]] = None
         self._last_action: Optional[cs.DM] = None
-        self._V, self._Q = self._setup_V_and_Q(mpcs, remove_bounds_on_initial_action)
+        self._V, self._Q = self._setup_V_and_Q(mpc, remove_bounds_on_initial_action)
         self._post_setup_V_and_Q()
 
     @property
@@ -558,13 +558,13 @@ class Agent(Named, SupportsDeepcopyAndPickle, AgentCallbackMixin, Generic[SymTyp
 
     def _setup_V_and_Q(
         self,
-        mpc: tuple[Mpc[SymType]] | tuple[Mpc[SymType], Mpc[SymType]],
+        mpc: Mpc[SymType] | tuple[Mpc[SymType], Mpc[SymType]],
         remove_bounds_on_initial_action: bool,
     ) -> tuple[Mpc[SymType], Mpc[SymType]]:
         """Internal utility to setup the function approximators for the value function
         ``V(s)`` and the quality function ``Q(s,a)``."""
         # create V and Q function approximations
-        V, Q = mpc if len(mpc) == 2 else (mpc[0], mpc[0].copy())
+        V, Q = mpc if isinstance(mpc, tuple) else (mpc, mpc.copy())
         V.unwrapped.name += "_V"
         Q.unwrapped.name += "_Q"
 

--- a/src/mpcrl/agents/common/agent.py
+++ b/src/mpcrl/agents/common/agent.py
@@ -558,13 +558,13 @@ class Agent(Named, SupportsDeepcopyAndPickle, AgentCallbackMixin, Generic[SymTyp
 
     def _setup_V_and_Q(
         self,
-        mpc: Mpc[SymType] | tuple[Mpc[SymType], Mpc[SymType]],
+        mpc: tuple[Mpc[SymType]] | tuple[Mpc[SymType], Mpc[SymType]],
         remove_bounds_on_initial_action: bool,
     ) -> tuple[Mpc[SymType], Mpc[SymType]]:
         """Internal utility to setup the function approximators for the value function
         ``V(s)`` and the quality function ``Q(s,a)``."""
         # create V and Q function approximations
-        V, Q = mpc if isinstance(mpc, tuple) else (mpc, mpc.copy())
+        V, Q = mpc if len(mpc) == 2 else (mpc[0], mpc[0].copy())
         V.unwrapped.name += "_V"
         Q.unwrapped.name += "_Q"
 

--- a/src/mpcrl/agents/common/agent.py
+++ b/src/mpcrl/agents/common/agent.py
@@ -48,13 +48,14 @@ class Agent(Named, SupportsDeepcopyAndPickle, AgentCallbackMixin, Generic[SymTyp
 
     Parameters
     ----------
-    mpc : :class:`csnlp.wrappers.Mpc`
-        The MPC controller used as policy provider by this agent. The instance is
-        modified in place to create the approximations of the state function
-        :math:`V_\theta(s)` and action value function :math:`Q_\theta(s,a)`, so it is
-        recommended not to modify it further after initialization of the agent.
-        Moreover, some parameter and constraint names will need to be created, so an
-        error is thrown if these names are already in use in the mpc.
+    mpc : :class:`csnlp.wrappers.Mpc` or tuple of :class:`csnlp.wrappers.Mpc`
+        The MPC controller used as policy provider by this agent. If a tuple, the
+        first entry is used to create the approximation of the state function
+        :math:`V_\theta(s)` and the second for that of  :math:`Q_\theta(s,a)`.
+        Otherwise, the instance is modified in place to create both approximations,
+        so it is recommended not to modify it further after initialization of the
+        agent. Moreover, some parameter and constraint names will need to be created,
+        so an error is thrown if these names are already in use in the mpc.
     fixed_parameters : dict of (str, array_like) or collection of, optional
         A dict (or collection of dict, in case of the ``mpc`` wrapping an underlying
         :class:`csnlp.multistart.MultistartNlp` instance) whose keys are the names of
@@ -128,7 +129,7 @@ class Agent(Named, SupportsDeepcopyAndPickle, AgentCallbackMixin, Generic[SymTyp
 
     def __init__(
         self,
-        mpc: Mpc[SymType],
+        mpc: Mpc[SymType] | tuple[Mpc[SymType], Mpc[SymType]],
         fixed_parameters: Union[
             None, dict[str, npt.ArrayLike], Collection[dict[str, npt.ArrayLike]]
         ] = None,
@@ -143,18 +144,24 @@ class Agent(Named, SupportsDeepcopyAndPickle, AgentCallbackMixin, Generic[SymTyp
         if isinstance(warmstart, str):
             warmstart = WarmStartStrategy(warmstart)
         ws_points = warmstart.n_points
-        if mpc.is_multi and ws_points != 0 and mpc.nlp.starts - ws_points not in (0, 1):
-            raise ValueError(
-                "A multistart MPC was given with {mpc.nlp.starts} multistarts, but the "
-                f"given warmstart strategy asks for {ws_points} starting points. "
-                "Expected either 0 warmstart points (i.e., it is disabled), or the same"
-                " number as MPC's multistarts, or at most one less."
-            )
-        elif not mpc.is_multi and ws_points > 0:
-            raise ValueError(
-                "Got a warmstart strategy with more than 0 starting points, but the "
-                "given does not have an underlying multistart NLP problem."
-            )
+        mpcs = (mpc,) if not isinstance(mpc, tuple) else mpc
+        for mpc in mpcs:
+            if (
+                mpc.is_multi
+                and ws_points != 0
+                and mpc.nlp.starts - ws_points not in (0, 1)
+            ):
+                raise ValueError(
+                    "A multistart MPC was given with {mpc.nlp.starts} multistarts, but the "
+                    f"given warmstart strategy asks for {ws_points} starting points. "
+                    "Expected either 0 warmstart points (i.e., it is disabled), or the same"
+                    " number as MPC's multistarts, or at most one less."
+                )
+            elif not mpc.is_multi and ws_points > 0:
+                raise ValueError(
+                    "Got a warmstart strategy with more than 0 starting points, but the "
+                    "given does not have an underlying multistart NLP problem."
+                )
         Named.__init__(self, name)
         SupportsDeepcopyAndPickle.__init__(self)
         AgentCallbackMixin.__init__(self)
@@ -166,7 +173,7 @@ class Agent(Named, SupportsDeepcopyAndPickle, AgentCallbackMixin, Generic[SymTyp
         self._last_action_on_fail = use_last_action_on_fail
         self._last_solution: Optional[Solution[SymType]] = None
         self._last_action: Optional[cs.DM] = None
-        self._V, self._Q = self._setup_V_and_Q(mpc, remove_bounds_on_initial_action)
+        self._V, self._Q = self._setup_V_and_Q(mpcs, remove_bounds_on_initial_action)
         self._post_setup_V_and_Q()
 
     @property
@@ -550,26 +557,28 @@ class Agent(Named, SupportsDeepcopyAndPickle, AgentCallbackMixin, Generic[SymTyp
         return returns
 
     def _setup_V_and_Q(
-        self, mpc: Mpc[SymType], remove_bounds_on_initial_action: bool
+        self,
+        mpc: Mpc[SymType] | tuple[Mpc[SymType], Mpc[SymType]],
+        remove_bounds_on_initial_action: bool,
     ) -> tuple[Mpc[SymType], Mpc[SymType]]:
         """Internal utility to setup the function approximators for the value function
         ``V(s)`` and the quality function ``Q(s,a)``."""
-        na = mpc.na
-        if na <= 0:
-            raise ValueError(f"Expected Mpc with na>0; got na={na} instead.")
-
         # create V and Q function approximations
-        V, Q = mpc, mpc.copy()
+        V, Q = mpc if isinstance(mpc, tuple) else (mpc, mpc.copy())
         V.unwrapped.name += "_V"
         Q.unwrapped.name += "_Q"
+
+        na = V.na
+        if na <= 0:
+            raise ValueError(f"Expected Mpc with na>0; got na={na} instead.")
 
         # for Q, add the additional constraint on the initial action to be equal to a0,
         # and remove the now useless upper/lower bounds on the initial action
         a0 = Q.nlp.parameter(self.init_action_parameter, (na, 1))
-        u0 = cs.vcat(mpc.first_actions.values())
+        u0 = cs.vcat(Q.first_actions.values())
         Q.nlp.constraint(self.init_action_constraint, u0, "==", a0)
         if remove_bounds_on_initial_action:
-            for name, a in mpc.first_actions.items():
+            for name, a in Q.first_actions.items():
                 na_ = a.size1()
                 Q.nlp.remove_variable_bounds(name, "both", ((r, 0) for r in range(na_)))
 
@@ -577,8 +586,8 @@ class Agent(Named, SupportsDeepcopyAndPickle, AgentCallbackMixin, Generic[SymTyp
         if self._exploration.mode == "gradient-based":
             perturbation = V.nlp.parameter(self.cost_perturbation_parameter, (na, 1))
             f = V.nlp.f
-            if mpc.is_wrapped(wrappers.NlpScaling):
-                f = mpc.scale(f)
+            if V.is_wrapped(wrappers.NlpScaling):
+                f = V.scale(f)
             V.nlp.minimize(f + cs.dot(perturbation, u0))
 
         # invalidate caches for V and Q since some modifications have been done

--- a/src/mpcrl/agents/lstd_dpg.py
+++ b/src/mpcrl/agents/lstd_dpg.py
@@ -46,13 +46,14 @@ class LstdDpgAgent(RlLearningAgent[SymType, ExpType, LrType], Generic[SymType, L
 
     Parameters
     ----------
-    mpc : :class:`csnlp.wrappers.Mpc`
-        The MPC controller used as policy provider by this agent. The instance is
-        modified in place to create the approximations of the state function
-        :math:`V_\theta(s)` and action value function :math:`Q_\theta(s,a)`, so it is
-        recommended not to modify it further after initialization of the agent.
-        Moreover, some parameter and constraint names will need to be created, so an
-        error is thrown if these names are already in use in the mpc.
+    mpc : :class:`csnlp.wrappers.Mpc` or tuple of :class:`csnlp.wrappers.Mpc`
+        The MPC controller used as policy provider by this agent. If a tuple, the
+        first entry is used to create the approximation of the state function
+        :math:`V_\theta(s)` and the second for that of  :math:`Q_\theta(s,a)`.
+        Otherwise, the instance is modified in place to create both approximations,
+        so it is recommended not to modify it further after initialization of the
+        agent. Moreover, some parameter and constraint names will need to be created,
+        so an error is thrown if these names are already in use in the mpc.
     update_strategy : UpdateStrategy or int
         The strategy used to decide which frequency to update the mpc parameters with.
         If an ``int`` is passed, then the default strategy that updates every ``n``
@@ -157,7 +158,7 @@ class LstdDpgAgent(RlLearningAgent[SymType, ExpType, LrType], Generic[SymType, L
 
     def __init__(
         self,
-        mpc: Mpc[SymType],
+        mpc: Mpc[SymType] | tuple[Mpc[SymType], Mpc[SymType]],
         update_strategy: Union[int, UpdateStrategy],
         discount_factor: float,
         optimizer: GradientBasedOptimizer,

--- a/src/mpcrl/agents/lstd_q_learning.py
+++ b/src/mpcrl/agents/lstd_q_learning.py
@@ -44,13 +44,14 @@ class LstdQLearningAgent(
 
     Parameters
     ----------
-    mpc : :class:`csnlp.wrappers.Mpc`
-        The MPC controller used as policy provider by this agent. The instance is
-        modified in place to create the approximations of the state function
-        :math:`V_\theta(s)` and action value function :math:`Q_\theta(s,a)`, so it is
-        recommended not to modify it further after initialization of the agent.
-        Moreover, some parameter and constraint names will need to be created, so an
-        error is thrown if these names are already in use in the mpc.
+    mpc : :class:`csnlp.wrappers.Mpc` or tuple of :class:`csnlp.wrappers.Mpc`
+        The MPC controller used as policy provider by this agent. If a tuple, the
+        first entry is used to create the approximation of the state function
+        :math:`V_\theta(s)` and the second for that of  :math:`Q_\theta(s,a)`.
+        Otherwise, the instance is modified in place to create both approximations,
+        so it is recommended not to modify it further after initialization of the
+        agent. Moreover, some parameter and constraint names will need to be created,
+        so an error is thrown if these names are already in use in the mpc.
     update_strategy : UpdateStrategy or int
         The strategy used to decide which frequency to update the mpc parameters with.
         If an ``int`` is passed, then the default strategy that updates every ``n``
@@ -125,7 +126,7 @@ class LstdQLearningAgent(
 
     def __init__(
         self,
-        mpc: Mpc[SymType],
+        mpc: Mpc[SymType] | tuple[Mpc[SymType], Mpc[SymType]],
         update_strategy: Union[int, UpdateStrategy],
         discount_factor: float,
         optimizer: GradientBasedOptimizer,


### PR DESCRIPTION
option to pass V and Q as seperate MPC instances to agent, thus avoiding a potentially expensive deepcopy operation.